### PR TITLE
Make all python values visible to the interpreter visible to sio

### DIFF
--- a/main.py
+++ b/main.py
@@ -261,7 +261,10 @@ class VarExpr(AST):
     def __repr__(self):
         return self.name
     def eval(self, state):
-        return state.lookup(self.name)
+        try:
+            return state.lookup(self.name)
+        except:
+            return eval(self.name)
 
 class Run(AST):
     def __init__(self, file: AST):
@@ -558,20 +561,7 @@ current_state = State()
 def get_current_state():
     return current_state.vals
 
-current_state.bind("int", int)
-current_state.bind("float", float)
-current_state.bind("str", str)
-current_state.bind("list", list)
-current_state.bind("tuple", tuple)
-current_state.bind("dict", dict)
-current_state.bind("open", open)
-current_state.bind("map", map)
-current_state.bind("zip", zip)
-current_state.bind("len", len)
-current_state.bind("print", print)
-current_state.bind("float", input)
-current_state.bind("callable", callable)
-current_state.bind("state_", get_current_state)
+current_state.bind("get_state", get_current_state)
 
 # Inputs
 while True:

--- a/main.py
+++ b/main.py
@@ -57,9 +57,13 @@ class Lexer:
             self.idx += 1
         return Token(TokenKind.INT, int(match))
 
+    def current_char_is_valid_in_an_identifier(self):
+        current = self.src[self.idx]
+        return current.isidentifier() or current == '.'
+
     def lex_ident(self):
         match = ""
-        while self.idx < len(self.src) and self.src[self.idx].isidentifier():
+        while self.idx < len(self.src) and self.current_char_is_valid_in_an_identifier():
             match += self.src[self.idx]
             self.idx += 1
         
@@ -123,7 +127,10 @@ class State:
     def bind(self, name, val):
         self.vals[name] = val
     def lookup(self, name):
-        return self.vals[name]
+        try:
+            return self.vals[name]
+        except:
+            return eval(name)
 
 class SequenceNode(AST):
   def __init__(self, first, second):
@@ -261,10 +268,7 @@ class VarExpr(AST):
     def __repr__(self):
         return self.name
     def eval(self, state):
-        try:
-            return state.lookup(self.name)
-        except:
-            return eval(self.name)
+        return state.lookup(self.name)
 
 class Run(AST):
     def __init__(self, file: AST):


### PR DESCRIPTION
When a variable lookup fails, instead of erroring, this looks up the value of the variable in python instead.
This means all the lines with e.g. `current_state.bind("str", str)` are no longer necessary unless you want to rename the function.

I edited the lexer a bit so you can have names like `sys.exit` which include a `.` in them. You still can't import external libraries into the interpreter from sio code though, so its up to you to import any modules into the interpreter you want accessible from sio. Additionally, many python functions may be hard to use since sio doesn't have any notion of arrays or maps.