### PR TITLE
Add array builtin to construct arrays

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-PlasmaAddict135from enum import Enum
+from enum import Enum
 from collections import defaultdict
 from os import error
 from typing import List, Dict

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from enum import Enum
+PlasmaAddict135from enum import Enum
 from collections import defaultdict
 from os import error
 from typing import List, Dict
@@ -574,7 +574,6 @@ current_state.bind("len", len)
 current_state.bind("print", print)
 current_state.bind("float", input)
 current_state.bind("callable", callable)
-current_state.bind("array", array)
 
 # Inputs
 while True:

--- a/main.py
+++ b/main.py
@@ -555,8 +555,11 @@ class Parser:
 current_state = State()
 
 # Builtins
-def get_current_state():
+def get_state():
     return current_state.vals
+
+def array(*args):
+    return list(args)
 
 current_state.bind("int", int)
 current_state.bind("float", float)
@@ -571,7 +574,7 @@ current_state.bind("len", len)
 current_state.bind("print", print)
 current_state.bind("float", input)
 current_state.bind("callable", callable)
-current_state.bind("state_", get_current_state)
+current_state.bind("array", array)
 
 # Inputs
 while True:


### PR DESCRIPTION
Example usage:
```
>>> var a = array(1, 2, 3)
[1, 2, 3]
```
This makes working with the builtin python functions easier since you can make arrays now.